### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules
 
 docs/annotated
 docs/coverage.html
+package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -1,32 +1,13 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-> A [Seneca.js][] message transport over beanstalkd queues.
+> A [Seneca.js][] plugin
 
-# seneca-beanstalk-transport
-[![Build Status][travis-badge]][travis-url]
-[![Gitter][gitter-badge]][gitter-url]
+# @seneca/beanstalk-transport
 
-[![js-standard-style][standard-badge]][standard-style]
-
-A transport module that uses [beanstalkd][] as it's engine. It may also be used as an example on how to
-implement a transport plugin for Seneca.
-
-- __Version:__ 0.2.1
-- __Node:__ 4, 6
-
-If you're using this module, and need help, you can:
-
-- Post a [github issue][],
-- Tweet to [@senecajs][],
-- Ask on the [Gitter][gitter-url].
-
-If you are new to Seneca in general, please take a look at [senecajs.org][]. We have everything from
-tutorials to sample apps to help get you up and running quickly.
-
-### Seneca compatibility
-
-Supports Seneca versions **1.x** - **3.x**
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
 ## Install
+
 To install, simply use npm. Remember you will need to install [Seneca.js][] if you haven't already.
 
 ```
@@ -37,30 +18,58 @@ npm install seneca-beanstalk-transport
 In order to use this transport, you need to have a [beanstalkd][] daemon running. The deamon
 and instructions on how to install can be found on the beanstalkd [install page][].
 
-## Test
-To run tests, simply use npm:
+## Quick Example
 
+```js
+require('seneca')()
+  .use('seneca-beanstalk-transport')
+  .listen({ type: 'beanstalk', pin: 'role:create' })
 ```
+
+## More Examples
+
+See [test/](test/) for usage examples.
+
+## Motivation
+
+Provides Beanstalk transport for Seneca microservice messages.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue][]
+- Tweet to [@senecajs][]
+
+## API
+
+See [seneca-transport](https://github.com/senecajs/seneca-transport) for configuration.
+
+## Contributing
+
+The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
+
+### Running tests
+
+```sh
 npm run test
 ```
 
-## Contributing
-The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with
-documentation, examples, extra testing, or new features please get in touch.
+## Background
 
-## License
-Copyright Richard Rodger and other contributors 2014-2016, Licensed under [MIT][].
+Uses the [fivebeans](https://github.com/ceejbot/fivebeans) client.
 
+[![Build Status][travis-badge]][travis-url]
+[![Gitter][gitter-badge]][gitter-url]
+[![js-standard-style][standard-badge]][standard-style]
 [travis-badge]: https://travis-ci.org/senecajs/seneca-beanstalk-transport.svg
 [travis-url]: https://travis-ci.org/senecajs/seneca-beanstalk-transport
 [gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
 [gitter-url]: https://gitter.im/senecajs/seneca
 [standard-badge]: https://raw.githubusercontent.com/feross/standard/master/badge.png
 [standard-style]: https://github.com/feross/standard
-
 [beanstalkd]: http://kr.github.io/beanstalkd/
 [install page]: http://kr.github.io/beanstalkd/download.html
-
 [MIT]: ./LICENSE
 [Senecajs org]: https://github.com/senecajs/
 [Seneca.js]: https://www.npmjs.com/package/seneca

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-beanstalk-transport",
+  "name": "@seneca/beanstalk-transport",
   "version": "0.2.1",
   "description": "Seneca beanstalk transport",
   "main": "lib/index.js",


### PR DESCRIPTION
## What changed
- Renamed default branch to `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`